### PR TITLE
Removing autoblock script

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -3,7 +3,6 @@ import React from 'react';
 export const onRenderBody = ({setHeadComponents}, pluginOptions) => {
   if (process.env.NODE_ENV === 'production' && !pluginOptions.skip) {
     setHeadComponents([
-      <script src={pluginOptions.autoBlockSrc} />,
       <script
         src={pluginOptions.otSDKStubSrc}
         type="text/javascript"


### PR DESCRIPTION
This PR removes OneTrust's AutoBlock script as we're moving to managing the blocking of scripts within our Google Tag Manager container.